### PR TITLE
Fix straightforward compilation errors

### DIFF
--- a/src/activation/mod.rs
+++ b/src/activation/mod.rs
@@ -12,8 +12,9 @@ pub fn swiglu_clamp<B: Backend, const D: usize>(
     alpha: f32,
     clamp_limit: Option<f32>,
 ) -> Tensor<B, D> {
-    let dims = tensor.dims();
-    let last = dims[dims.len() - 1];
+    let mut dims = tensor.dims();
+    let last_index = dims.len() - 1;
+    let last = dims[last_index];
     assert!(last % 2 == 0, "SwiGLU input last dimension must be even");
     let half = last / 2;
 
@@ -28,10 +29,9 @@ pub fn swiglu_clamp<B: Backend, const D: usize>(
     let mut activated = swish * value;
 
     if let Some(limit) = clamp_limit {
-        activated = activated.clamp_scalar(-limit, limit);
+        activated = activated.clamp(-limit, limit);
     }
 
-    let mut final_shape = dims.to_vec();
-    final_shape[dims.len() - 1] = half;
-    activated.reshape(final_shape)
+    dims[last_index] = half;
+    activated.reshape(dims)
 }

--- a/src/attention/linear.rs
+++ b/src/attention/linear.rs
@@ -72,8 +72,9 @@ impl<B: Backend> LinearAttention<B> {
         let q = self.attn_linear(input.query, &self.query);
         let mut k = self.attn_linear(input.key, &self.key);
         let mut v = self.attn_linear(input.value, &self.value);
-        if let Some(mask) = input.mask_pad.clone() {
-            let mask = mask.reshape([batch_size, 1, mask.dims()[1], 1]);
+        if let Some(mask) = input.mask_pad.as_ref() {
+            let dims = mask.dims();
+            let mask = mask.clone().reshape([batch_size, 1, dims[1], 1]);
             k = k.mask_fill(mask.clone(), 0.0);
             v = v.mask_fill(mask, 0.0);
         }

--- a/src/attention/mask1d.rs
+++ b/src/attention/mask1d.rs
@@ -1,6 +1,6 @@
 use burn_core as burn;
 
-use burn::tensor::{Bool, Int, Shape, Tensor, backend::Backend};
+use burn::tensor::{Bool, Tensor, backend::Backend};
 
 /// Generate a 1D padding mask from sequence lengths: [B, max_len], true marks padding.
 pub fn lengths_to_mask<B: Backend>(lengths: &[usize], max_len: usize, device: &B::Device) -> Tensor<B, 2, Bool> {

--- a/src/attention/streaming_mqa.rs
+++ b/src/attention/streaming_mqa.rs
@@ -8,7 +8,6 @@ use burn::{
 };
 
 use super::AttnWindow;
-use burn_tensor::activation::{quiet_softmax, softmax};
 
 /// Configuration for streaming multi-query attention (MQA/GQA).
 #[derive(Config, Debug)]
@@ -344,8 +343,8 @@ impl<B: Backend> StreamingMultiQueryAttention<B> {
         let mut attn_scores = crate::attention::compute_scores(q, k_exp, self.d_k, &self.dropout);
 
         // Additive attention bias (already shaped to window)
-        if let Some(bias) = params.attn_bias.clone() {
-            attn_scores = attn_scores + bias;
+        if let Some(bias) = params.attn_bias {
+            attn_scores = attn_scores + bias.clone();
         }
 
         // Optional sinks bias: append as a sentinel column and then discard after softmax.

--- a/src/bias/mod.rs
+++ b/src/bias/mod.rs
@@ -1,6 +1,7 @@
 use burn_core as burn;
 
 use burn::tensor::{Int, Tensor, backend::Backend};
+use burn_tensor::TensorData;
 
 /// Build sinks bias from a flat per-head vector shaped [n_heads] into [kv_heads, groups].
 pub fn sinks_from_per_head<B: Backend>(per_head: Tensor<B, 1>, kv_heads: usize, groups: usize) -> Tensor<B, 2> {
@@ -18,7 +19,8 @@ pub fn alibi_bias<B: Backend>(
     device: &B::Device,
 ) -> Tensor<B, 4> {
     let s = if let Some(s) = slopes { s.to_vec() } else { default_slopes(n_heads) };
-    let slopes = Tensor::<B, 1>::from_floats(s, device).reshape([n_heads, 1, 1]);
+    let slopes = Tensor::<B, 1>::from_floats(TensorData::new(s, [n_heads]), device)
+        .reshape([n_heads, 1, 1]);
     let q = Tensor::<B, 1, Int>::arange(0..q_len as i64, device).float().reshape([q_len, 1]);
     let k = Tensor::<B, 1, Int>::arange(0..k_len as i64, device).float().reshape([1, k_len]);
     let dist = q - k; // [q_len, k_len]

--- a/src/diffusion/pingpong.rs
+++ b/src/diffusion/pingpong.rs
@@ -106,7 +106,7 @@ impl<B: Backend, const D: usize> DiffusionScheduler<B, D> for FlowMatchPingPong<
         let sigma_next = self.sigmas[i + 1];
 
         let denoised = sample.clone() - model_output.mul_scalar(sigma);
-        let shape = denoised.shape().dims();
+        let shape: [usize; D] = denoised.shape().dims();
         let noise = Tensor::<B, D>::random(shape, Distribution::Default, &denoised.device());
         let prev_sample = denoised.mul_scalar(1.0 - sigma_next) + noise.mul_scalar(sigma_next);
 

--- a/src/generate/runner.rs
+++ b/src/generate/runner.rs
@@ -1,7 +1,7 @@
 use burn_core as burn;
 
 use burn::tensor::backend::Backend;
-use crate::attention::{AttnWindow, StreamingMhaCache, StreamingMqaCache, StreamingMqaParams, StreamingParams};
+use crate::attention::{AttnWindow, StreamingMqaParams, StreamingParams};
 
 /// Minimal streaming state for chunked decoding.
 #[derive(Clone, Debug)]
@@ -17,18 +17,18 @@ impl StreamState {
 }
 
 impl StreamState {
-    pub fn params_mha<B: Backend>(
-        &self,
-        rope: Option<&burn::nn::RotaryEncoding<B>>,
-    ) -> StreamingParams<B> {
+    pub fn params_mha<'a, B: Backend>(
+        &'a self,
+        rope: Option<&'a burn::nn::RotaryEncoding<B>>,
+    ) -> StreamingParams<'a, B> {
         StreamingParams { rope, start_pos: self.start_pos, window: self.window }
     }
 
-    pub fn params_mqa<B: Backend>(
-        &self,
-        rope: Option<&burn::nn::RotaryEncoding<B>>,
-        sinks: Option<&burn::tensor::Tensor<B, 2>>,
-    ) -> StreamingMqaParams<B> {
+    pub fn params_mqa<'a, B: Backend>(
+        &'a self,
+        rope: Option<&'a burn::nn::RotaryEncoding<B>>,
+        sinks: Option<&'a burn::tensor::Tensor<B, 2>>,
+    ) -> StreamingMqaParams<'a, B> {
         StreamingMqaParams { rope, start_pos: self.start_pos, window: self.window, sinks, attn_bias: None }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 // Alias burn-core as `burn` so derive macros and internal paths match expectations.
+#[allow(unused_imports)]
 use burn_core as burn;
 
 pub mod attention;


### PR DESCRIPTION
## Summary
- update activation and attention helpers to use available tensor operations without moving values
- refresh sampling, generation, and bias utilities to use the latest TensorData conversions and RNG API
- repair SafeTensors loaders to avoid duplicate crate versions, add missing trait imports, and read files manually when std support is absent

## Testing
- cargo check --color never

------
https://chatgpt.com/codex/tasks/task_e_68c8f46da83c8322bb96127ef25f2f8e